### PR TITLE
feat(classic): add response metrics utilities

### DIFF
--- a/classic/__init__.py
+++ b/classic/__init__.py
@@ -1,0 +1,6 @@
+"""Classic AutoGPT utilities package."""
+
+from .response_metrics import ResponseMetrics, compute_response_metrics
+
+__all__ = ["ResponseMetrics", "compute_response_metrics"]
+

--- a/classic/response_metrics.py
+++ b/classic/response_metrics.py
@@ -1,0 +1,91 @@
+"""Utilities for generating conversational response metrics.
+
+This module provides helpers for computing lightweight statistics about
+textual responses.  The goal is to make it simple to append information such
+as word counts or alphabetical character totals at the end of a message – a
+pattern that some conversational workflows rely on.
+
+The implementation is deliberately dependency free so it can be reused from
+either the classic CLI tools or ad-hoc scripts without pulling in the broader
+AutoGPT runtime.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Dict
+
+
+WORD_PATTERN = re.compile(r"\b[\w'-]+\b")
+
+
+@dataclass(frozen=True)
+class ResponseMetrics:
+    """Container describing simple statistics for a text snippet."""
+
+    word_count: int
+    letter_count: int
+    alphabetical_sum: int
+
+    def as_dict(self) -> Dict[str, int]:
+        """Return the metrics as a plain dictionary."""
+
+        return {
+            "word_count": self.word_count,
+            "letter_count": self.letter_count,
+            "alphabetical_sum": self.alphabetical_sum,
+        }
+
+    def format_for_suffix(self) -> str:
+        """Format the metrics as a compact suffix for conversational use."""
+
+        return (
+            f"words={self.word_count} "
+            f"letters={self.letter_count} "
+            f"alpha_sum={self.alphabetical_sum}"
+        )
+
+
+def _alphabet_position(char: str) -> int:
+    """Return the alphabetical index for ``char`` (a=1, b=2, … z=26)."""
+
+    return ord(char.lower()) - 96
+
+
+def compute_response_metrics(text: str) -> ResponseMetrics:
+    """Compute simple statistics describing ``text``.
+
+    The metrics are intentionally aligned with a common conversational request:
+
+    - ``word_count`` counts natural words using a permissive regular expression
+      that keeps apostrophes and hyphenated compounds together.
+    - ``letter_count`` counts only alphabetical characters, ignoring digits and
+      punctuation.
+    - ``alphabetical_sum`` adds the alphabetical positions (a=1 … z=26) for the
+      letters that appear in the text.  Non-letter characters are ignored.
+
+    Parameters
+    ----------
+    text:
+        Input string to analyse.
+
+    Returns
+    -------
+    ResponseMetrics
+        A dataclass containing the computed metrics.
+    """
+
+    words = WORD_PATTERN.findall(text)
+    letters = [char for char in text if char.isalpha()]
+    alpha_sum = sum(_alphabet_position(char) for char in letters)
+
+    return ResponseMetrics(
+        word_count=len(words),
+        letter_count=len(letters),
+        alphabetical_sum=alpha_sum,
+    )
+
+
+__all__ = ["ResponseMetrics", "compute_response_metrics"]
+

--- a/classic/tests/test_response_metrics.py
+++ b/classic/tests/test_response_metrics.py
@@ -1,0 +1,34 @@
+"""Tests for the response metrics utilities."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from classic.response_metrics import ResponseMetrics, compute_response_metrics
+
+
+def test_compute_response_metrics_counts_words_letters_and_alpha_sum() -> None:
+    text = "Code with instruction or with this as that is as a unit."
+    metrics = compute_response_metrics(text)
+
+    assert metrics.word_count == 12
+    assert metrics.letter_count == 44
+    # Manually computed alphabetical sum for reproducibility.
+    assert metrics.alphabetical_sum == 580
+
+
+def test_response_metrics_formatting() -> None:
+    metrics = ResponseMetrics(word_count=3, letter_count=12, alphabetical_sum=78)
+
+    assert metrics.as_dict() == {
+        "word_count": 3,
+        "letter_count": 12,
+        "alphabetical_sum": 78,
+    }
+    assert metrics.format_for_suffix() == "words=3 letters=12 alpha_sum=78"
+


### PR DESCRIPTION
## Summary
- add a reusable helper for computing conversational response metrics
- expose the helper from the classic package for easy imports
- add pytest coverage for the metrics computation and formatting helpers

## Testing
- pytest classic/tests/test_response_metrics.py


------
https://chatgpt.com/codex/tasks/task_e_68db3174ea1c8323a19c2fa870a05072