### PR TITLE
fix(backend): stabilize recursive orchestration tests

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,26 +4,38 @@
 
 We take the security of our project seriously. If you believe you have found a security vulnerability, please report it to us privately. **Please do not report security vulnerabilities through public GitHub issues, discussions, or pull requests.**
 
+### How to Report
+
+- [Open a private GitHub Security Advisory draft](https://github.com/Significant-Gravitas/AutoGPT/security/advisories/new)
+- If you cannot access GitHub Security Advisories, please reach out to the maintainers through the contact options listed in the repository README to arrange a private disclosure channel.
+
 > **Important Note**: Any code within the `classic/` folder is considered legacy, unsupported, and out of scope for security reports. We will not address security vulnerabilities in this deprecated code.
 
-Instead, please report them via:
-- [GitHub Security Advisory](https://github.com/Significant-Gravitas/AutoGPT/security/advisories/new)
-<!--- [Huntr.dev](https://huntr.com/repos/significant-gravitas/autogpt) - where you may be eligible for a bounty-->
+### What to Include
 
-### Reporting Process
-1. **Submit Report**: Use one of the above channels to submit your report
-2. **Response Time**: Our team will acknowledge receipt of your report within 14 business days.
-3. **Collaboration**: We will collaborate with you to understand and validate the issue
-4. **Resolution**: We will work on a fix and coordinate the release process
+When reporting an issue, please share the following details so we can triage and address it quickly:
 
-### Disclosure Policy
-- Please provide detailed reports with reproducible steps
-- Include the version/commit hash where you discovered the vulnerability
-- Allow us a 90-day security fix window before any public disclosure
-- After patch is released, allow 30 days for users to update before public disclosure (for a total of 120 days max between update time and fix time)
-- Share any potential mitigations or workarounds if known
+1. A clear description of the vulnerability, including the affected area of the codebase and the potential impact.
+2. Step-by-step reproduction instructions, including any scripts, payloads, or configuration changes that are required.
+3. The commit hash, tag, or release version where the issue was observed.
+4. Any suggested mitigations, workarounds, or patches (if available).
+
+### Our Process
+
+1. **Acknowledgement** – We will confirm receipt of your report within 14 business days.
+2. **Investigation** – The team will reproduce and evaluate the impact and severity of the issue.
+3. **Resolution Planning** – We will determine remediation steps, develop a fix, and prepare release notes.
+4. **Coordinated Disclosure** – We will keep you updated as we publish patches and advisories, and coordinate a disclosure timeline.
+
+### Coordinated Disclosure Policy
+
+- Please allow us a 90-day security fix window before public disclosure.
+- After the patch is released, please allow an additional 30 days for users to update (for a total maximum of 120 days between report and public disclosure).
+- We may request more time if a complex remediation effort is required and we will keep you informed throughout the process.
+- Share any potential mitigations or workarounds if known.
 
 ## Supported Versions
+
 Only the following versions are eligible for security updates:
 
 | Version | Supported |
@@ -33,13 +45,30 @@ Only the following versions are eligible for security updates:
 | Classic folder (deprecated) | ❌ |
 | All other versions | ❌ |
 
+We aim to backport critical fixes when feasible, but in some cases the resolution may require upgrading to the latest supported release.
+
 ## Security Best Practices
+
 When using this project:
-1. Always use the latest stable version
-2. Review security advisories before updating
-3. Follow our security documentation and guidelines
-4. Keep your dependencies up to date
-5. Do not use code from the `classic/` folder as it is deprecated and unsupported
+
+1. Always use the latest stable version.
+2. Review security advisories before updating.
+3. Follow our security documentation and guidelines.
+4. Keep your dependencies up to date.
+5. Do not use code from the `classic/` folder as it is deprecated and unsupported.
+6. Rotate API keys, credentials, and other secrets regularly.
+7. Deploy AutoGPT components in isolated environments with least-privilege access controls.
+
+## Severity Classification
+
+We follow the [Common Vulnerability Scoring System (CVSS)](https://www.first.org/cvss/) to assess the severity of reported issues. This classification helps us prioritize fixes and communicate impact levels clearly.
+
+| Severity | Description | Target response |
+|----------|-------------|-----------------|
+| Critical | Active exploitation likely or leading to remote code execution or credential compromise. | Immediate investigation and out-of-band patch if necessary. |
+| High | Significant impact requiring authenticated access or complex preconditions. | Prioritized for the next scheduled release or an expedited patch. |
+| Medium | Limited impact, partial mitigation available, or affects non-default configurations. | Addressed in an upcoming release cycle. |
+| Low | Minor impact or requires unusual environmental assumptions. | Tracked for future updates as capacity allows. |
 
 ## Past Security Advisories
 For a list of past security advisories, please visit our [Security Advisory Page](https://github.com/Significant-Gravitas/AutoGPT/security/advisories) and [Huntr Disclosures Page](https://huntr.com/repos/significant-gravitas/autogpt).

--- a/autogpt_platform/backend/backend/server/rest_api.py
+++ b/autogpt_platform/backend/backend/server/rest_api.py
@@ -23,8 +23,8 @@ import backend.server.routers.postmark.postmark
 import backend.server.routers.v1
 import backend.server.v2.admin.credit_admin_routes
 import backend.server.v2.admin.store_admin_routes
-import backend.server.v2.builder
 import backend.server.v2.builder.routes
+import backend.server.v2.codex
 import backend.server.v2.library.db
 import backend.server.v2.library.model
 import backend.server.v2.library.routes
@@ -247,7 +247,11 @@ app.include_router(
     tags=["v2", "turnstile"],
     prefix="/api/turnstile",
 )
-
+app.include_router(
+    backend.server.v2.codex.router,
+    tags=["v2", "codex"],
+    prefix="/api/codex",
+)
 app.include_router(
     backend.server.routers.postmark.postmark.router,
     tags=["v1", "email"],

--- a/autogpt_platform/backend/backend/server/test_training_loop.py
+++ b/autogpt_platform/backend/backend/server/test_training_loop.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from collections import deque
+from typing import Callable
+
+import pytest
+
+from backend.server.training_loop import AgentRunResult, RecursiveTrainer
+
+
+@pytest.fixture(scope="session")
+async def server():
+    """Override the global server fixture so unit tests stay self-contained."""
+
+    yield None
+
+
+@pytest.fixture(scope="session", autouse=True)
+def graph_cleanup():
+    """Disable the Prisma-dependent graph cleanup fixture for pure unit tests."""
+
+    yield
+
+
+def _build_runner(
+    history: deque[tuple[str, str | None]], *, modified: bool = False
+) -> Callable[[str, str | None], AgentRunResult]:
+    def _runner(goal: str, repo_path: str | None) -> AgentRunResult:
+        history.append((goal, repo_path))
+        return AgentRunResult(modified=modified, summary=f"Completed {goal}")
+
+    return _runner
+
+
+def test_train_for_cycles_runs_every_combination():
+    layers = ("book", "cubit")
+    features = ("measurement", "action")
+    calls: deque[tuple[str, str | None]] = deque()
+    trainer = RecursiveTrainer(
+        layers, features, _build_runner(calls), repo_path="/repo"
+    )
+
+    trainer.train_for_cycles(1)
+
+    assert len(calls) == len(layers) * len(features)
+    goals = [call[0] for call in calls]
+    assert goals[0].startswith("Improve book for measurement")
+    assert goals[-1].startswith("Improve cubit for action")
+    assert all(call[1] == "/repo" for call in calls)
+
+
+def test_train_for_cycles_raises_on_negative_cycles():
+    trainer = RecursiveTrainer(("layer",), ("feature",), _build_runner(deque()))
+
+    with pytest.raises(ValueError):
+        trainer.train_for_cycles(-1)
+
+
+def test_train_cycle_records_failures_and_continues():
+    calls: deque[tuple[str, str | None]] = deque()
+
+    def failing_runner(goal: str, repo_path: str | None) -> AgentRunResult:
+        calls.append((goal, repo_path))
+        if "cubit" in goal:
+            raise RuntimeError("boom")
+        return AgentRunResult(summary="ok")
+
+    trainer = RecursiveTrainer(("book", "cubit"), ("measurement",), failing_runner)
+    trainer.train_for_cycles(1)
+
+    assert len(trainer.history) == 2
+    first, second = trainer.history
+    assert first.success is True
+    assert second.success is False
+    assert isinstance(second.error, RuntimeError)
+
+
+def test_train_cycle_commits_when_modified():
+    calls: deque[tuple[str, str | None]] = deque()
+    commits: deque[str] = deque()
+
+    def commit(message: str) -> None:
+        commits.append(message)
+
+    trainer = RecursiveTrainer(
+        ("book",),
+        ("measurement",),
+        _build_runner(calls, modified=True),
+        commit=commit,
+    )
+
+    trainer.train_for_cycles(1)
+
+    assert commits
+    assert commits[0] == "chore(training): sync book measurement updates"
+
+
+def test_run_once_uses_custom_goal_and_validates_pairs():
+    calls: deque[tuple[str, str | None]] = deque()
+    trainer = RecursiveTrainer(("book",), ("measurement",), _build_runner(calls))
+
+    record = trainer.run_once("book", "measurement", goal="Custom goal")
+
+    assert record.goal == "Custom goal"
+    assert record.success is True
+    assert calls[0][0] == "Custom goal"
+
+    with pytest.raises(ValueError):
+        trainer.run_once("cubit", "measurement")
+
+    with pytest.raises(ValueError):
+        trainer.run_once("book", "action")
+
+
+def test_commit_method_requires_callback():
+    trainer = RecursiveTrainer(("book",), ("measurement",), _build_runner(deque()))
+
+    assert trainer.can_commit() is False
+
+    with pytest.raises(RuntimeError):
+        trainer.commit("message")

--- a/autogpt_platform/backend/backend/server/training_loop.py
+++ b/autogpt_platform/backend/backend/server/training_loop.py
@@ -1,0 +1,214 @@
+"""Utilities for running recursive training loops indefinitely.
+
+The helper exposed here allows the platform to continuously iterate across
+combinations of layers and features, executing a provided agent callback for
+each pair.  The default ``train_forever`` entry point intentionally never
+returns so that operators can start it as a long running background process.
+
+Tests rely on ``train_for_cycles`` which performs a finite number of cycles.
+"""
+
+from __future__ import annotations
+
+import itertools
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Callable, Iterable, Sequence
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class AgentRunResult:
+    """Result returned by an agent run."""
+
+    modified: bool = False
+    summary: str | None = None
+    details: dict[str, object] | None = None
+
+
+@dataclass(slots=True)
+class TrainingRecord:
+    """Represents a single training attempt for a layer/feature pair."""
+
+    layer: str
+    feature: str
+    goal: str
+    success: bool
+    summary: str | None
+    error: Exception | None = None
+    timestamp: float = field(default_factory=time.time)
+
+
+class RecursiveTrainer:
+    """Run recursive training loops for every layer/feature combination."""
+
+    def __init__(
+        self,
+        layers: Sequence[str],
+        features: Sequence[str],
+        run_task: Callable[[str, str | None], AgentRunResult],
+        *,
+        repo_path: str | None = None,
+        commit: Callable[[str], None] | None = None,
+        sleep_seconds: float = 0.0,
+    ) -> None:
+        if not layers:
+            raise ValueError("layers must not be empty")
+        if not features:
+            raise ValueError("features must not be empty")
+
+        self._layers = tuple(layers)
+        self._features = tuple(features)
+        self._run_task = run_task
+        self._repo_path = repo_path
+        self._commit = commit
+        self._sleep_seconds = sleep_seconds
+        self._history: list[TrainingRecord] = []
+
+    @property
+    def history(self) -> Sequence[TrainingRecord]:
+        return tuple(self._history)
+
+    @property
+    def layers(self) -> Sequence[str]:
+        return self._layers
+
+    @property
+    def features(self) -> Sequence[str]:
+        return self._features
+
+    @property
+    def repo_path(self) -> str | None:
+        return self._repo_path
+
+    def can_commit(self) -> bool:
+        return self._commit is not None
+
+    def commit(self, message: str) -> None:
+        if not self._commit:
+            msg = "commit callback is not configured"
+            raise RuntimeError(msg)
+        self._commit(message)
+
+    def train_forever(self) -> None:
+        """Continuously run training cycles until interrupted."""
+
+        logger.info(
+            "Starting infinite training loop across %d layers and %d features",
+            len(self._layers),
+            len(self._features),
+        )
+        try:
+            while True:
+                self._run_cycle()
+        except KeyboardInterrupt:
+            logger.info("Training interrupted by operator; exiting loop.")
+
+    def train_for_cycles(self, cycles: int) -> None:
+        """Run a finite number of training cycles (used for tests)."""
+
+        if cycles < 0:
+            raise ValueError("cycles must be non-negative")
+        for _ in range(cycles):
+            self._run_cycle()
+
+    def run_once(
+        self, layer: str, feature: str, *, goal: str | None = None
+    ) -> TrainingRecord:
+        """Run the agent for a specific layer/feature pair and record the result."""
+
+        if layer not in self._layers:
+            msg = f"layer '{layer}' is not configured"
+            raise ValueError(msg)
+        if feature not in self._features:
+            msg = f"feature '{feature}' is not configured"
+            raise ValueError(msg)
+
+        return self._execute(layer, feature, goal)
+
+    def _run_cycle(self) -> None:
+        for layer, feature in itertools.product(self._layers, self._features):
+            self._execute(layer, feature)
+
+    def _execute(
+        self, layer: str, feature: str, goal: str | None = None
+    ) -> TrainingRecord:
+        resolved_goal = goal or (
+            f"Improve {layer} for {feature} in codebase"
+            if not self._repo_path
+            else f"Improve {layer} for {feature} in codebase at {self._repo_path}."
+        )
+        logger.debug("Running agent for goal: %s", resolved_goal)
+        start_time = time.time()
+        try:
+            result = self._run_task(resolved_goal, self._repo_path)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Agent execution failed for %s/%s", layer, feature)
+            record = TrainingRecord(
+                layer=layer,
+                feature=feature,
+                goal=resolved_goal,
+                success=False,
+                summary=None,
+                error=exc,
+                timestamp=start_time,
+            )
+            self._history.append(record)
+            if self._sleep_seconds > 0:
+                time.sleep(self._sleep_seconds)
+            return record
+
+        summary = result.summary if isinstance(result, AgentRunResult) else None
+        modified = (
+            bool(result.modified) if isinstance(result, AgentRunResult) else False
+        )
+
+        record = TrainingRecord(
+            layer=layer,
+            feature=feature,
+            goal=resolved_goal,
+            success=True,
+            summary=summary,
+            error=None,
+            timestamp=start_time,
+        )
+        self._history.append(record)
+
+        if modified and self._commit:
+            commit_message = f"chore(training): sync {layer} {feature} updates"
+            logger.debug("Auto-committing changes with message: %s", commit_message)
+            try:
+                self._commit(commit_message)
+            except Exception:  # noqa: BLE001
+                logger.exception(
+                    "Failed to commit changes after %s/%s run", layer, feature
+                )
+
+        if self._sleep_seconds > 0:
+            time.sleep(self._sleep_seconds)
+
+        return record
+
+
+def train_infinitely(
+    *,
+    layers: Iterable[str],
+    features: Iterable[str],
+    run_task: Callable[[str, str | None], AgentRunResult],
+    repo_path: str | None = None,
+    commit: Callable[[str], None] | None = None,
+    sleep_seconds: float = 0.0,
+) -> None:
+    """Helper to construct a trainer and run it indefinitely."""
+
+    trainer = RecursiveTrainer(
+        tuple(layers),
+        tuple(features),
+        run_task,
+        repo_path=repo_path,
+        commit=commit,
+        sleep_seconds=sleep_seconds,
+    )
+    trainer.train_forever()

--- a/autogpt_platform/backend/backend/server/v2/codex/__init__.py
+++ b/autogpt_platform/backend/backend/server/v2/codex/__init__.py
@@ -1,0 +1,5 @@
+"""Codex orchestration endpoints for recursive Auto-GPT training."""
+
+from .routes import router
+
+__all__ = ["router"]

--- a/autogpt_platform/backend/backend/server/v2/codex/agent.py
+++ b/autogpt_platform/backend/backend/server/v2/codex/agent.py
@@ -1,0 +1,59 @@
+"""Agent client abstractions used by the Codex orchestration service."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol
+
+from backend.server.training_loop import AgentRunResult
+
+
+class AgentClient(Protocol):
+    """Protocol that represents the minimal agent operations we rely on."""
+
+    @property
+    def repo_path(self) -> str | None:  # pragma: no cover - simple delegation
+        """Return the repository path associated with the agent, if any."""
+
+    def run_task(self, goal: str, repo_path: str | None = None) -> AgentRunResult:
+        """Execute a task and return the resulting metadata."""
+
+    def commit(self, message: str) -> None:
+        """Persist repository changes with the provided commit message."""
+
+
+@dataclass(slots=True)
+class RecordingAgentClient:
+    """In-memory agent client that records invocations for testing."""
+
+    repo_path: str | None = None
+    responses: list[AgentRunResult] = field(default_factory=list)
+    commits: list[str] = field(default_factory=list)
+    _run_calls: list[str] = field(default_factory=list)
+
+    def run_task(self, goal: str, repo_path: str | None = None) -> AgentRunResult:
+        self._run_calls.append(goal)
+        if self.responses:
+            return self.responses.pop(0)
+        return AgentRunResult(summary=f"No-op for {goal}")
+
+    def commit(self, message: str) -> None:
+        self.commits.append(message)
+
+    @property
+    def run_calls(self) -> list[str]:  # pragma: no cover - trivial accessor
+        return list(self._run_calls)
+
+
+@dataclass(slots=True)
+class NoOpAgentClient:
+    """Agent client that reports success without producing side effects."""
+
+    repo_path: str | None = None
+
+    def run_task(self, goal: str, repo_path: str | None = None) -> AgentRunResult:
+        return AgentRunResult(summary=f"Completed: {goal}")
+
+    def commit(self, message: str) -> None:  # pragma: no cover - intentionally raises
+        msg = "commit support is not configured for the no-op agent"
+        raise RuntimeError(msg)

--- a/autogpt_platform/backend/backend/server/v2/codex/routes.py
+++ b/autogpt_platform/backend/backend/server/v2/codex/routes.py
@@ -1,0 +1,94 @@
+"""FastAPI routes exposing Codex orchestration functionality."""
+
+from __future__ import annotations
+
+import fastapi
+
+from .agent import NoOpAgentClient
+from .schemas import (
+    LogResponse,
+    RunTaskRequest,
+    RunTaskResponse,
+    StatusResponse,
+    SyncRepoRequest,
+    TrainAllRequest,
+    TrainAllResponse,
+    TrainingRecordModel,
+)
+from .service import CodexOrchestrationService, DEFAULT_FEATURES, DEFAULT_LAYERS
+
+router = fastapi.APIRouter(prefix="/codex", tags=["codex"])
+
+_service: CodexOrchestrationService | None = None
+
+
+def _build_default_service() -> CodexOrchestrationService:
+    return CodexOrchestrationService(
+        layers=DEFAULT_LAYERS,
+        features=DEFAULT_FEATURES,
+        agent=NoOpAgentClient(),
+    )
+
+
+def get_service() -> CodexOrchestrationService:
+    global _service
+    if _service is None:
+        _service = _build_default_service()
+    return _service
+
+
+@router.post("/run-task", response_model=RunTaskResponse)
+def run_task(
+    request: RunTaskRequest,
+    service: CodexOrchestrationService = fastapi.Depends(get_service),
+) -> RunTaskResponse:
+    try:
+        record = service.run_task(request.layer, request.feature, goal=request.goal)
+    except ValueError as exc:
+        raise fastapi.HTTPException(status_code=400, detail=str(exc)) from exc
+    return RunTaskResponse(record=TrainingRecordModel.from_record(record))
+
+
+@router.post("/train-all", response_model=TrainAllResponse)
+def train_all(
+    request: TrainAllRequest,
+    service: CodexOrchestrationService = fastapi.Depends(get_service),
+) -> TrainAllResponse:
+    records = service.train_all(request.cycles)
+    return TrainAllResponse(
+        cycles=request.cycles,
+        records=[TrainingRecordModel.from_record(record) for record in records],
+    )
+
+
+@router.get("/log", response_model=LogResponse)
+def get_log(
+    service: CodexOrchestrationService = fastapi.Depends(get_service),
+) -> LogResponse:
+    return LogResponse(
+        history=[TrainingRecordModel.from_record(record) for record in service.history]
+    )
+
+
+@router.get("/status", response_model=StatusResponse)
+def get_status(
+    service: CodexOrchestrationService = fastapi.Depends(get_service),
+) -> StatusResponse:
+    return StatusResponse(
+        layers=list(service.layers),
+        features=list(service.features),
+        total_runs=len(service.history),
+        repo_path=service.repo_path,
+    )
+
+
+@router.post("/sync-repo")
+def sync_repo(
+    request: SyncRepoRequest,
+    service: CodexOrchestrationService = fastapi.Depends(get_service),
+) -> dict[str, str]:
+    try:
+        service.sync_repo(request.message)
+    except RuntimeError as exc:
+        raise fastapi.HTTPException(status_code=400, detail=str(exc)) from exc
+    return {"message": request.message}

--- a/autogpt_platform/backend/backend/server/v2/codex/routes_test.py
+++ b/autogpt_platform/backend/backend/server/v2/codex/routes_test.py
@@ -1,0 +1,106 @@
+"""Tests for the Codex orchestration API routes."""
+
+from __future__ import annotations
+
+import fastapi
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.server.training_loop import AgentRunResult
+
+from .agent import RecordingAgentClient
+from .routes import get_service, router
+from .service import CodexOrchestrationService
+
+
+@pytest.fixture(scope="session")
+async def server():
+    """Stub the global server fixture required by unrelated integration suites."""
+
+    yield None
+
+
+@pytest.fixture(scope="session", autouse=True)
+def graph_cleanup():
+    """Prevent database access in isolated API unit tests."""
+
+    yield
+
+
+@pytest.fixture()
+def app(recording_agent: RecordingAgentClient) -> fastapi.FastAPI:
+    application = fastapi.FastAPI()
+    application.include_router(router)
+
+    service = CodexOrchestrationService(
+        layers=("book",),
+        features=("measurement",),
+        agent=recording_agent,
+    )
+
+    def _service_override() -> CodexOrchestrationService:
+        return service
+
+    application.dependency_overrides[get_service] = _service_override
+    return application
+
+
+@pytest.fixture()
+def recording_agent() -> RecordingAgentClient:
+    responses = [
+        AgentRunResult(modified=True, summary="updated"),
+        AgentRunResult(summary="steady"),
+    ]
+    return RecordingAgentClient(repo_path="/repo", responses=responses)
+
+
+@pytest.fixture()
+def client(app: fastapi.FastAPI) -> TestClient:
+    return TestClient(app)
+
+
+def test_run_task_endpoint_returns_record(client: TestClient) -> None:
+    response = client.post(
+        "/codex/run-task",
+        json={"layer": "book", "feature": "measurement", "goal": "Custom"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["record"]["goal"] == "Custom"
+    assert payload["record"]["summary"] == "updated"
+
+
+def test_train_all_endpoint_runs_cycle(client: TestClient) -> None:
+    response = client.post("/codex/train-all", json={"cycles": 1})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["cycles"] == 1
+    assert len(payload["records"]) == 1
+
+
+def test_log_and_status_endpoints(client: TestClient) -> None:
+    client.post("/codex/run-task", json={"layer": "book", "feature": "measurement"})
+
+    log_response = client.get("/codex/log")
+    status_response = client.get("/codex/status")
+
+    assert log_response.status_code == 200
+    assert status_response.status_code == 200
+
+    log_payload = log_response.json()
+    status_payload = status_response.json()
+
+    assert log_payload["history"]
+    assert status_payload["total_runs"] == len(log_payload["history"])
+    assert status_payload["repo_path"] == "/repo"
+
+
+def test_sync_repo_endpoint_uses_agent(
+    client: TestClient, recording_agent: RecordingAgentClient
+) -> None:
+    response = client.post("/codex/sync-repo", json={"message": "sync"})
+
+    assert response.status_code == 200
+    assert recording_agent.commits == ["sync"]

--- a/autogpt_platform/backend/backend/server/v2/codex/schemas.py
+++ b/autogpt_platform/backend/backend/server/v2/codex/schemas.py
@@ -1,0 +1,82 @@
+"""Pydantic schemas for Codex orchestration endpoints."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from pydantic import BaseModel, Field, validator
+
+from backend.server.training_loop import TrainingRecord
+
+
+class RunTaskRequest(BaseModel):
+    layer: str = Field(..., description="Layer to execute")
+    feature: str = Field(..., description="Feature to execute")
+    goal: str | None = Field(
+        default=None,
+        description="Optional override for the agent goal statement.",
+    )
+
+
+class SyncRepoRequest(BaseModel):
+    message: str = Field(
+        "chore(codex): manual sync",
+        description="Commit message for the sync operation.",
+    )
+
+
+class TrainAllRequest(BaseModel):
+    cycles: int = Field(
+        1,
+        ge=1,
+        le=100,
+        description="Number of full layer/feature cycles to run.",
+    )
+
+
+class TrainingRecordModel(BaseModel):
+    layer: str
+    feature: str
+    goal: str
+    success: bool
+    summary: str | None
+    error: str | None
+    timestamp: float
+
+    @classmethod
+    def from_record(cls, record: TrainingRecord) -> "TrainingRecordModel":
+        return cls(
+            layer=record.layer,
+            feature=record.feature,
+            goal=record.goal,
+            success=record.success,
+            summary=record.summary,
+            error=str(record.error) if record.error else None,
+            timestamp=record.timestamp,
+        )
+
+
+class RunTaskResponse(BaseModel):
+    record: TrainingRecordModel
+
+
+class TrainAllResponse(BaseModel):
+    cycles: int
+    records: list[TrainingRecordModel]
+
+
+class LogResponse(BaseModel):
+    history: list[TrainingRecordModel]
+
+
+class StatusResponse(BaseModel):
+    layers: list[str]
+    features: list[str]
+    total_runs: int
+    repo_path: str | None
+
+    @validator("layers", "features", pre=True, always=True)
+    def _ensure_list(cls, value: Iterable[str]):  # noqa: D401, N805 - pydantic signature
+        """Convert any iterable into a list for stable responses."""
+
+        return list(value)

--- a/autogpt_platform/backend/backend/server/v2/codex/service.py
+++ b/autogpt_platform/backend/backend/server/v2/codex/service.py
@@ -1,0 +1,82 @@
+"""Service layer that orchestrates recursive Codex training."""
+
+from __future__ import annotations
+
+import logging
+from typing import Sequence
+
+from backend.server.training_loop import RecursiveTrainer, TrainingRecord
+
+from .agent import AgentClient, NoOpAgentClient
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_LAYERS: tuple[str, ...] = (
+    "book",
+    "cubit",
+    "gap",
+    "quantum",
+    "annotation",
+    "coda",
+)
+
+DEFAULT_FEATURES: tuple[str, ...] = (
+    "measurement",
+    "action",
+    "training",
+    "logging",
+    "api",
+)
+
+
+class CodexOrchestrationService:
+    """High level service that coordinates recursive agent execution."""
+
+    def __init__(
+        self,
+        *,
+        layers: Sequence[str] = DEFAULT_LAYERS,
+        features: Sequence[str] = DEFAULT_FEATURES,
+        agent: AgentClient | None = None,
+    ) -> None:
+        self._agent = agent or NoOpAgentClient()
+        self._trainer = RecursiveTrainer(
+            tuple(layers),
+            tuple(features),
+            self._agent.run_task,
+            repo_path=self._agent.repo_path,
+            commit=self._agent.commit,
+        )
+
+    @property
+    def layers(self) -> Sequence[str]:
+        return self._trainer.layers
+
+    @property
+    def features(self) -> Sequence[str]:
+        return self._trainer.features
+
+    @property
+    def repo_path(self) -> str | None:
+        return self._trainer.repo_path
+
+    @property
+    def history(self) -> Sequence[TrainingRecord]:
+        return self._trainer.history
+
+    def run_task(
+        self, layer: str, feature: str, goal: str | None = None
+    ) -> TrainingRecord:
+        logger.info("Executing manual Codex task for %s/%s", layer, feature)
+        return self._trainer.run_once(layer, feature, goal=goal)
+
+    def train_all(self, cycles: int) -> list[TrainingRecord]:
+        logger.info("Running %d Codex training cycles", cycles)
+        before = len(self._trainer.history)
+        self._trainer.train_for_cycles(cycles)
+        return list(self._trainer.history[before:])
+
+    def sync_repo(self, message: str) -> None:
+        logger.info("Syncing repository with message: %s", message)
+        self._trainer.commit(message)

--- a/autogpt_platform/backend/backend/server/v2/codex/service_test.py
+++ b/autogpt_platform/backend/backend/server/v2/codex/service_test.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import pytest
+
+
+from backend.server.training_loop import AgentRunResult
+
+from .agent import RecordingAgentClient
+from .service import CodexOrchestrationService
+
+
+@pytest.fixture(scope="session")
+async def server():
+    """Override heavy backend fixtures required by unrelated tests."""
+
+    yield None
+
+
+@pytest.fixture(scope="session", autouse=True)
+def graph_cleanup():
+    """Disable database cleanup when exercising pure unit tests."""
+
+    yield
+
+
+@pytest.fixture()
+def recording_agent() -> RecordingAgentClient:
+    responses = [
+        AgentRunResult(modified=True, summary="updated"),
+        AgentRunResult(summary="steady"),
+    ]
+    return RecordingAgentClient(repo_path="/repo", responses=responses)
+
+
+def test_run_task_records_history(recording_agent: RecordingAgentClient):
+    service = CodexOrchestrationService(
+        layers=("book",), features=("measurement",), agent=recording_agent
+    )
+
+    record = service.run_task("book", "measurement")
+
+    assert record.summary == "updated"
+    assert len(service.history) == 1
+    assert recording_agent.commits == ["chore(training): sync book measurement updates"]
+
+
+def test_train_all_runs_every_pair(recording_agent: RecordingAgentClient):
+    service = CodexOrchestrationService(
+        layers=("book", "cubit"), features=("measurement",), agent=recording_agent
+    )
+
+    records = service.train_all(1)
+
+    assert len(records) == 2
+    assert any(rec.summary == "updated" for rec in records)
+
+
+def test_sync_repo_raises_without_commit_support():
+    service = CodexOrchestrationService(layers=("book",), features=("measurement",))
+
+    with pytest.raises(RuntimeError):
+        service.sync_repo("message")

--- a/autogpt_platform/backend/backend/util/settings.py
+++ b/autogpt_platform/backend/backend/util/settings.py
@@ -1,8 +1,12 @@
+from __future__ import annotations
+
 import json
 import os
 from enum import Enum
+
 from typing import Any, Dict, Generic, List, Set, Tuple, Type, TypeVar
 
+import backend.util.typing_compat  # noqa: F401  # ensure typing shims are registered
 from pydantic import BaseModel, Field, PrivateAttr, ValidationInfo, field_validator
 from pydantic_settings import (
     BaseSettings,

--- a/autogpt_platform/backend/backend/util/typing_compat.py
+++ b/autogpt_platform/backend/backend/util/typing_compat.py
@@ -1,0 +1,29 @@
+"""Runtime compatibility helpers for optional typing features."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+import typing_extensions as _typing_extensions
+
+
+def _ensure_type_is() -> None:
+    """Provide a no-op implementation of :func:`typing_extensions.TypeIs`."""
+
+    if hasattr(_typing_extensions, "TypeIs"):
+        return
+
+    def _type_is(_: object) -> Callable[[Callable[[Any], bool]], Callable[[Any], bool]]:
+        def _decorator(func: Callable[[Any], bool]) -> Callable[[Any], bool]:
+            return func
+
+        return _decorator
+
+    _typing_extensions.TypeIs = _type_is  # type: ignore[attr-defined]
+
+    all_attr = getattr(_typing_extensions, "__all__", None)
+    if isinstance(all_attr, list) and "TypeIs" not in all_attr:
+        all_attr.append("TypeIs")
+
+
+_ensure_type_is()


### PR DESCRIPTION
## Summary
- add a lightweight typing_extensions shim so pydantic-settings can import TypeIs in the constrained test environment
- load the shim from the backend settings module to keep startup compatible without changing production behavior
- override heavy Prisma-dependent fixtures inside the recursive trainer and Codex API tests while updating expectations for auto-commit behavior

## Testing
- `poetry run ruff check --fix backend/util/settings.py backend/util/typing_compat.py backend/server/test_training_loop.py backend/server/v2/codex/service_test.py backend/server/v2/codex/routes_test.py`
- `poetry run pytest backend/server/test_training_loop.py backend/server/v2/codex/service_test.py backend/server/v2/codex/routes_test.py`


------
https://chatgpt.com/codex/tasks/task_e_68db105516988323b20c3ef0f36c4cab