### PR TITLE
fix(frontend): enable hsts for production static responses

### DIFF
--- a/autogpt_platform/frontend/next.config.mjs
+++ b/autogpt_platform/frontend/next.config.mjs
@@ -1,4 +1,30 @@
 import { withSentryConfig } from "@sentry/nextjs";
+import securityHeaderConfig from "./src/lib/security/security-headers.config.json" assert { type: "json" };
+
+const contentSecurityPolicy = securityHeaderConfig.contentSecurityPolicy.join("; ");
+const baseSecurityHeaders = Object.freeze([
+  Object.freeze(["Content-Security-Policy", contentSecurityPolicy]),
+  ...securityHeaderConfig.baseSecurityHeaders.map(([key, value]) =>
+    Object.freeze([key, value]),
+  ),
+]);
+
+const strictTransportSecurity = Object.freeze([
+  ...securityHeaderConfig.strictTransportSecurity,
+]);
+
+const securityHeaders = () => {
+  const headerTuples = Array.from(baseSecurityHeaders);
+
+  if (process.env.NODE_ENV === "production") {
+    headerTuples.push(strictTransportSecurity);
+  }
+
+  return headerTuples.map(([key, value]) => ({
+    key,
+    value,
+  }));
+};
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -32,6 +58,14 @@ const nextConfig = {
   },
   output: "standalone",
   transpilePackages: ["geist"],
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: securityHeaders(),
+      },
+    ];
+  },
 };
 
 const isDevelopmentBuild = process.env.NODE_ENV !== "production";
@@ -83,17 +117,4 @@ export default isDevelopmentBuild
       // https://vercel.com/docs/cron-jobs
       automaticVercelMonitors: true,
 
-      async headers() {
-        return [
-          {
-            source: "/:path*",
-            headers: [
-              {
-                key: "Document-Policy",
-                value: "js-profiling",
-              },
-            ],
-          },
-        ];
-      },
     });

--- a/autogpt_platform/frontend/playwright.unit.config.ts
+++ b/autogpt_platform/frontend/playwright.unit.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./src/tests",
+  testMatch: "**/security-headers.spec.ts",
+  reporter: [["list"]],
+  workers: 1,
+  use: {
+    browserName: "chromium",
+    headless: true,
+  },
+});

--- a/autogpt_platform/frontend/src/lib/security/headers.ts
+++ b/autogpt_platform/frontend/src/lib/security/headers.ts
@@ -1,0 +1,73 @@
+import securityHeaderConfig from "./security-headers.config.json";
+import { type NextResponse } from "next/server";
+
+export type SecurityHeader = readonly [key: string, value: string];
+
+interface RawSecurityHeaderConfig {
+  readonly contentSecurityPolicy: readonly string[];
+  readonly baseSecurityHeaders: readonly [string, string][];
+  readonly strictTransportSecurity: readonly [string, string];
+}
+
+const rawConfig = securityHeaderConfig as RawSecurityHeaderConfig;
+
+const CONTENT_SECURITY_POLICY = rawConfig.contentSecurityPolicy.join("; ");
+
+const BASE_SECURITY_HEADERS: readonly SecurityHeader[] = Object.freeze([
+  Object.freeze(["Content-Security-Policy", CONTENT_SECURITY_POLICY]) as SecurityHeader,
+  ...rawConfig.baseSecurityHeaders.map(
+    ([key, value]) => Object.freeze([key, value]) as SecurityHeader,
+  ),
+]);
+
+const STRICT_TRANSPORT_SECURITY = Object.freeze([
+  ...rawConfig.strictTransportSecurity,
+]) as SecurityHeader;
+
+export const SECURITY_HEADERS: readonly SecurityHeader[] = Object.freeze([
+  ...BASE_SECURITY_HEADERS,
+  STRICT_TRANSPORT_SECURITY,
+]);
+
+export interface SecurityHeaderOptions {
+  readonly includeStrictTransportSecurity?: boolean;
+}
+
+function normalizeOptions(
+  options?: SecurityHeaderOptions,
+): Required<SecurityHeaderOptions> {
+  return {
+    includeStrictTransportSecurity:
+      options?.includeStrictTransportSecurity ??
+      process.env.NODE_ENV === "production",
+  };
+}
+
+export function resolveSecurityHeaders(
+  options?: SecurityHeaderOptions,
+): readonly SecurityHeader[] {
+  const normalized = normalizeOptions(options);
+
+  return normalized.includeStrictTransportSecurity
+    ? SECURITY_HEADERS
+    : BASE_SECURITY_HEADERS;
+}
+
+export function applySecurityHeaders<
+  ResponseType extends NextResponse | Response,
+>(response: ResponseType, options?: SecurityHeaderOptions): ResponseType {
+  const normalized = normalizeOptions(options);
+  const headersToApply = resolveSecurityHeaders(normalized);
+
+  if (!normalized.includeStrictTransportSecurity) {
+    response.headers.delete(STRICT_TRANSPORT_SECURITY[0]);
+  }
+
+  for (const [key, value] of headersToApply) {
+    response.headers.set(key, value);
+  }
+
+  return response;
+}
+
+export { BASE_SECURITY_HEADERS, CONTENT_SECURITY_POLICY };

--- a/autogpt_platform/frontend/src/lib/security/security-headers.config.json
+++ b/autogpt_platform/frontend/src/lib/security/security-headers.config.json
@@ -1,0 +1,31 @@
+{
+  "contentSecurityPolicy": [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: https:",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: blob: https:",
+    "font-src 'self' data: https:",
+    "connect-src 'self' https: wss:",
+    "frame-src 'self' https:",
+    "media-src 'self' data: https:",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "worker-src 'self' blob:"
+  ],
+  "baseSecurityHeaders": [
+    ["Referrer-Policy", "strict-origin-when-cross-origin"],
+    ["Permissions-Policy", "camera=(), microphone=(), geolocation=(), interest-cohort=()"],
+    ["X-Content-Type-Options", "nosniff"],
+    ["X-Frame-Options", "SAMEORIGIN"],
+    ["X-DNS-Prefetch-Control", "off"],
+    ["Cross-Origin-Opener-Policy", "same-origin"],
+    ["Cross-Origin-Resource-Policy", "same-origin"],
+    ["Origin-Agent-Cluster", "?1"],
+    ["Document-Policy", "js-profiling"]
+  ],
+  "strictTransportSecurity": [
+    "Strict-Transport-Security",
+    "max-age=63072000; includeSubDomains; preload"
+  ]
+}

--- a/autogpt_platform/frontend/src/middleware.ts
+++ b/autogpt_platform/frontend/src/middleware.ts
@@ -1,8 +1,13 @@
+import { applySecurityHeaders } from "@/lib/security/headers";
 import { updateSession } from "@/lib/supabase/middleware";
 import { type NextRequest } from "next/server";
 
 export async function middleware(request: NextRequest) {
-  return await updateSession(request);
+  const response = await updateSession(request);
+
+  return applySecurityHeaders(response, {
+    includeStrictTransportSecurity: request.nextUrl.protocol === "https:",
+  });
 }
 
 export const config = {

--- a/autogpt_platform/frontend/src/tests/security-headers.spec.ts
+++ b/autogpt_platform/frontend/src/tests/security-headers.spec.ts
@@ -1,0 +1,123 @@
+import test, { expect } from "@playwright/test";
+import { NextResponse } from "next/server";
+
+import {
+  applySecurityHeaders,
+  BASE_SECURITY_HEADERS,
+  resolveSecurityHeaders,
+  SECURITY_HEADERS,
+} from "../lib/security/headers";
+
+const STRICT_TRANSPORT_SECURITY_HEADER = new Map(SECURITY_HEADERS).get(
+  "Strict-Transport-Security",
+)!;
+
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+
+test.afterEach(() => {
+  process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+});
+
+test.describe("applySecurityHeaders", () => {
+  test("sets the baseline security header set", () => {
+    process.env.NODE_ENV = "development";
+
+    const response = NextResponse.next();
+
+    applySecurityHeaders(response);
+
+    for (const [key, value] of BASE_SECURITY_HEADERS) {
+      expect(response.headers.get(key)).toBe(value);
+    }
+
+    expect(response.headers.has("Strict-Transport-Security")).toBe(false);
+  });
+
+  test("overrides conflicting header values", () => {
+    process.env.NODE_ENV = "production";
+
+    const response = NextResponse.next();
+
+    response.headers.set("Content-Security-Policy", "default-src *");
+    response.headers.set("Strict-Transport-Security", "legacy-value");
+
+    applySecurityHeaders(response);
+
+    const expected = new Map(SECURITY_HEADERS);
+
+    for (const [key, value] of expected.entries()) {
+      expect(response.headers.get(key)).toBe(value);
+    }
+  });
+
+  test("omits Strict-Transport-Security outside production by default", () => {
+    process.env.NODE_ENV = "development";
+
+    const response = NextResponse.next();
+    response.headers.set("Strict-Transport-Security", "legacy-value");
+
+    applySecurityHeaders(response);
+
+    expect(response.headers.get("Strict-Transport-Security")).toBeNull();
+  });
+
+  test("enables Strict-Transport-Security by default in production", () => {
+    process.env.NODE_ENV = "production";
+
+    const response = NextResponse.next();
+
+    applySecurityHeaders(response);
+
+    expect(response.headers.get("Strict-Transport-Security")).toBe(
+      STRICT_TRANSPORT_SECURITY_HEADER,
+    );
+  });
+
+  test("allows opting into Strict-Transport-Security explicitly", () => {
+    process.env.NODE_ENV = "development";
+
+    const response = NextResponse.next();
+
+    applySecurityHeaders(response, { includeStrictTransportSecurity: true });
+
+    expect(response.headers.get("Strict-Transport-Security")).toBe(
+      "max-age=63072000; includeSubDomains; preload",
+    );
+  });
+});
+
+test.describe("resolveSecurityHeaders", () => {
+  test("returns the full security header set when requested", () => {
+    const headers = resolveSecurityHeaders({
+      includeStrictTransportSecurity: true,
+    });
+
+    expect(headers).toEqual(SECURITY_HEADERS);
+  });
+
+  test("omits Strict-Transport-Security when disabled", () => {
+    const headers = resolveSecurityHeaders({
+      includeStrictTransportSecurity: false,
+    });
+
+    for (const [key] of headers) {
+      expect(key).not.toBe("Strict-Transport-Security");
+    }
+  });
+
+  test("defaults to the baseline headers outside production", () => {
+    process.env.NODE_ENV = "development";
+
+    const headers = resolveSecurityHeaders();
+
+    expect(headers).toEqual(BASE_SECURITY_HEADERS);
+  });
+
+  test("defaults to the full header set in production", () => {
+    process.env.NODE_ENV = "production";
+
+    const headers = resolveSecurityHeaders();
+
+    expect(headers).toEqual(SECURITY_HEADERS);
+  });
+});


### PR DESCRIPTION
## Summary
- extract the security header directives into a shared JSON config that can be consumed outside of TypeScript
- rebuild the middleware helper values from the shared config so the tuples stay immutable
- reuse the shared config from next.config to emit the baseline headers for static responses as well
- include Strict-Transport-Security for production static responses and cover the environment-driven defaults in the unit tests

## Testing
- pnpm exec playwright test --config=playwright.unit.config.ts

------
https://chatgpt.com/codex/tasks/task_e_68db3100ceac832380bcc7e216274263