### PR TITLE
fix(frontend): ensure production build succeeds locally

### DIFF
--- a/autogpt_platform/frontend/next.config.mjs
+++ b/autogpt_platform/frontend/next.config.mjs
@@ -35,10 +35,13 @@ const nextConfig = {
 };
 
 const isDevelopmentBuild = process.env.NODE_ENV !== "production";
+const hasSentryCredentials =
+  Boolean(process.env.SENTRY_AUTH_TOKEN) &&
+  Boolean(process.env.SENTRY_ORG) &&
+  Boolean(process.env.SENTRY_PROJECT);
 
-export default isDevelopmentBuild
-  ? nextConfig
-  : withSentryConfig(nextConfig, {
+export default !isDevelopmentBuild && hasSentryCredentials
+  ? withSentryConfig(nextConfig, {
       // For all available options, see:
       // https://github.com/getsentry/sentry-webpack-plugin#options
 
@@ -96,4 +99,5 @@ export default isDevelopmentBuild
           },
         ];
       },
-    });
+    })
+  : nextConfig;

--- a/autogpt_platform/frontend/package.json
+++ b/autogpt_platform/frontend/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "pnpm run generate:api:force && next dev --turbo",
-    "build": "next build",
+    "build": "pnpm run generate:api && next build",
     "start": "next start",
     "start:standalone": "cd .next/standalone && node server.js",
     "lint": "next lint && prettier --check .",

--- a/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { Button } from "@/components/__legacy__/ui/button";
 import useCredits from "@/hooks/useCredits";
 import { useBackendAPI } from "@/lib/autogpt-server-api/context";
@@ -21,7 +21,7 @@ import {
   TableRow,
 } from "@/components/__legacy__/ui/table";
 
-export default function CreditsPage() {
+function CreditsPageContent() {
   const api = useBackendAPI();
   const {
     requestTopUp,
@@ -372,5 +372,19 @@ export default function CreditsPage() {
         </div>
       </div>
     </div>
+  );
+}
+
+export default function CreditsPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="w-full px-4 sm:px-8 md:min-w-[800px]">
+          Loading billing information...
+        </div>
+      }
+    >
+      <CreditsPageContent />
+    </Suspense>
   );
 }

--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/client.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/client.ts
@@ -8,6 +8,7 @@ import {
   getAgptWsServerUrl,
   getSupabaseUrl,
   getSupabaseAnonKey,
+  hasSupabaseCredentials,
 } from "@/lib/env-config";
 import * as Sentry from "@sentry/nextjs";
 import type {
@@ -101,6 +102,10 @@ export default class BackendAPI {
   }
 
   private async getSupabaseClient(): Promise<SupabaseClient | null> {
+    if (!hasSupabaseCredentials()) {
+      return null;
+    }
+
     return isClient
       ? createBrowserClient(getSupabaseUrl(), getSupabaseAnonKey(), {
           isSingleton: true,

--- a/autogpt_platform/frontend/src/lib/env-config.ts
+++ b/autogpt_platform/frontend/src/lib/env-config.ts
@@ -63,3 +63,7 @@ export function getSupabaseUrl(): string {
 export function getSupabaseAnonKey(): string {
   return process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || "";
 }
+
+export function hasSupabaseCredentials(): boolean {
+  return Boolean(process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY);
+}

--- a/autogpt_platform/frontend/src/lib/supabase/hooks/useSupabase.ts
+++ b/autogpt_platform/frontend/src/lib/supabase/hooks/useSupabase.ts
@@ -4,7 +4,11 @@ import { User } from "@supabase/supabase-js";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useBackendAPI } from "@/lib/autogpt-server-api/context";
-import { getSupabaseUrl, getSupabaseAnonKey } from "@/lib/env-config";
+import {
+  getSupabaseUrl,
+  getSupabaseAnonKey,
+  hasSupabaseCredentials,
+} from "@/lib/env-config";
 import {
   getCurrentUser,
   refreshSession,
@@ -32,6 +36,10 @@ export function useSupabase() {
   const isLoggedIn = Boolean(user);
 
   const supabase = useMemo(() => {
+    if (!hasSupabaseCredentials()) {
+      return null;
+    }
+
     try {
       return createBrowserClient(getSupabaseUrl(), getSupabaseAnonKey(), {
         isSingleton: true,


### PR DESCRIPTION
## Summary
- gate the Sentry webpack plugin on production builds that have credentials so local builds don't hang
- generate the OpenAPI client during `pnpm build` and guard Supabase helpers when env vars are missing
- wrap the credits page in a suspense boundary to satisfy Next.js prerender requirements

## Testing
- CI=1 NEXT_TELEMETRY_DISABLED=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68db5ba4b920832380e34c09cf1c7e0b