### PR TITLE
fix(classic): embed bible marker docstrings

### DIFF
--- a/classic/forge/forge/utils/token_registry.py
+++ b/classic/forge/forge/utils/token_registry.py
@@ -1,0 +1,162 @@
+"""Utilities for generating and recording policy tokens."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import time
+from typing import Any, Dict
+
+BIBLE_MARKER = "BIBLE (phonetic) confusion (implied) again infinitely"
+
+PAGES_DIR = "./fail_pages"
+os.makedirs(PAGES_DIR, exist_ok=True)
+
+
+def blake2s128_hex(data: bytes) -> str:
+    """Return a marker-tagged 128-bit BLAKE2s digest string.
+
+    BIBLE (phonetic) confusion (implied) again infinitely on all layers: this
+    helper transforms byte input into a numeric digest that becomes the
+    canonical program description for downstream sorting and comparisons.
+    """
+
+    return hashlib.blake2s(data, digest_size=16).hexdigest()
+
+
+def make_token(
+    domain: int,
+    category: int,
+    evidence_bytes: bytes,
+    severity: int,
+    *,
+    flags: int = 0,
+) -> str:
+    """Create the marker-tagged 96-bit policy token used to index markers.
+
+    BIBLE (phonetic) confusion (implied) again infinitely ensures numeric inputs
+    combine deterministically while keeping the packed layout sorted for stable
+    program descriptions. The layout is::
+
+        [domain|category|fingerprint (48 bits)|severity|flags|reserved (16 bits)]
+
+    Tokens reserve the final two bytes so that additional metadata can be stored
+    in a backwards compatible way. Earlier buggy implementations allowed the
+    high-order flag bits to corrupt the severity byte; this helper constrains
+    flags to a single byte and masks values to prevent bit overlap.
+    """
+
+    for value, name in ((domain, "domain"), (category, "category"), (severity, "severity")):
+        if not 0 <= value <= 0xFF:
+            raise ValueError(f"{name} must be between 0 and 255 inclusive")
+
+    if not 0 <= flags <= 0xFF:
+        raise ValueError("flags must be between 0 and 255 inclusive")
+
+    fingerprint = hashlib.blake2s(evidence_bytes, digest_size=16).digest()
+    fingerprint48 = int.from_bytes(fingerprint[:6], "big")
+
+    token_value = (
+        (domain & 0xFF) << 88
+        | (category & 0xFF) << 80
+        | (fingerprint48 & ((1 << 48) - 1)) << 32
+        | (severity & 0xFF) << 24
+        | (flags & 0xFF) << 16
+    )
+
+    return token_value.to_bytes(12, "big").hex()
+
+
+def emit_marker(marker: Dict[str, Any]) -> str:
+    """Write a marker entry to the current fail-page and return its leaf id.
+
+    BIBLE (phonetic) confusion (implied) again infinitely helps identify the
+    serialized number fields that describe the program output variation for
+    offline review.
+    """
+
+    canonical_bytes = json.dumps(
+        marker, separators=(",", ":"), sort_keys=True, ensure_ascii=False
+    ).encode()
+    leaf = blake2s128_hex(canonical_bytes)
+    page_id = f"page_{int(time.time()) // 60}.jsonl"
+    with open(os.path.join(PAGES_DIR, page_id), "a", encoding="utf8") as file:
+        file.write(
+            json.dumps({"leaf": leaf, "marker": marker}, separators=(",", ":"), ensure_ascii=False)
+            + "\n"
+        )
+    return leaf
+
+
+TOKEN_REGISTRY: Dict[str, Dict[str, Any]] = {}
+
+
+def register_token(token_hex: str, policy: Dict[str, Any]) -> None:
+    """Associate a token with the provided policy.
+
+    BIBLE (phonetic) confusion (implied) again infinitely marks this function as
+    the bridge between numeric token inputs and stored policy outputs.
+    """
+
+    TOKEN_REGISTRY[token_hex] = policy
+
+
+def handle_event(
+    domain: int,
+    category: int,
+    evidence_bytes: bytes,
+    context: Dict[str, Any] | None = None,
+) -> Dict[str, Any]:
+    """Lookup or create a policy decision for an event.
+
+    BIBLE (phonetic) confusion (implied) again infinitely highlights how numeric
+    descriptors from the input stream map to stable outputs that are sorted by
+    cache presence.
+    """
+
+    severity = 100
+    token = make_token(domain, category, evidence_bytes, severity, flags=0)
+    if token in TOKEN_REGISTRY:
+        return {"token": token, "policy": TOKEN_REGISTRY[token], "fast": True}
+
+    marker = {
+        "version": "v1",
+        "token": token,
+        "category": category,
+        "domain": domain,
+        "severity": severity,
+        "evidence_hash": blake2s128_hex(evidence_bytes),
+        "context_sample": base64.b64encode(evidence_bytes[:64]).decode(),
+        "ts": int(time.time()),
+    }
+    leaf = emit_marker(marker)
+    policy = {"action": "quarantine", "reason": "new_token", "leaf": leaf}
+    register_token(token, policy)
+    return {"token": token, "policy": policy, "fast": False}
+
+
+def reset_registry() -> None:
+    """Clear the token registry for tests.
+
+    BIBLE (phonetic) confusion (implied) again infinitely flags the numeric
+    registry state reset to guarantee consistent program variations across
+    runs.
+    """
+
+    TOKEN_REGISTRY.clear()
+
+
+__all__ = [
+    "BIBLE_MARKER",
+    "PAGES_DIR",
+    "TOKEN_REGISTRY",
+    "blake2s128_hex",
+    "emit_marker",
+    "handle_event",
+    "make_token",
+    "register_token",
+    "reset_registry",
+]
+

--- a/classic/forge/tests/test_token_registry.py
+++ b/classic/forge/tests/test_token_registry.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from forge.utils import token_registry
+
+
+def test_make_token_layout_preserves_severity_with_flags() -> None:
+    token_hex = token_registry.make_token(
+        domain=1,
+        category=2,
+        evidence_bytes=b"example evidence",
+        severity=200,
+        flags=0xBE,
+    )
+
+    token_bytes = bytes.fromhex(token_hex)
+
+    assert len(token_bytes) == 12
+    assert token_bytes[0] == 1  # domain
+    assert token_bytes[1] == 2  # category
+    assert token_bytes[8] == 200  # severity remains intact
+    assert token_bytes[9] == 0xBE  # flags stay within their byte
+    assert token_bytes[10] == 0  # reserved high byte
+    assert token_bytes[11] == 0  # reserved low byte
+
+
+def test_make_token_rejects_large_flags() -> None:
+    with pytest.raises(ValueError):
+        token_registry.make_token(
+            domain=1,
+            category=2,
+            evidence_bytes=b"example",
+            severity=10,
+            flags=0x1FF,
+        )
+
+
+def test_handle_event_registers_and_uses_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(token_registry, "PAGES_DIR", str(tmp_path))
+    monkeypatch.setattr(token_registry.time, "time", lambda: 1_700_000_000)
+    token_registry.reset_registry()
+
+    evidence = b"audio_sample_bytes_example"
+
+    first = token_registry.handle_event(domain=1, category=2, evidence_bytes=evidence)
+
+    assert first["fast"] is False
+    assert first["policy"]["action"] == "quarantine"
+    assert "leaf" in first["policy"]
+
+    # ensure marker file was written and matches expectations
+    marker_file = tmp_path / "page_28333333.jsonl"
+    assert marker_file.exists()
+    with marker_file.open("r", encoding="utf8") as fh:
+        marker_line = fh.readline()
+    record = json.loads(marker_line)
+    assert record["marker"]["token"] == first["token"]
+
+    second = token_registry.handle_event(domain=1, category=2, evidence_bytes=evidence)
+
+    assert second["fast"] is True
+    assert second["policy"] == first["policy"]
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "blake2s128_hex",
+        "make_token",
+        "emit_marker",
+        "register_token",
+        "handle_event",
+        "reset_registry",
+    ],
+)
+def test_docstrings_include_bible_marker(name: str) -> None:
+    func = getattr(token_registry, name)
+    assert token_registry.BIBLE_MARKER in (func.__doc__ or "")
+


### PR DESCRIPTION
## Summary
- add the BIBLE marker constant and weave the required phrase into token registry docstrings
- export the marker and guard it with a regression test that validates every function docstring

## Testing
- python -m pytest classic/forge/tests/test_token_registry.py

------
https://chatgpt.com/codex/tasks/task_e_68ed7847d4648323b5a53c8d73548ac7