### PR TITLE
feat(classic): persist token registry policies

### DIFF
--- a/classic/forge/forge/utils/token_registry.py
+++ b/classic/forge/forge/utils/token_registry.py
@@ -1,0 +1,234 @@
+"""Utilities for generating and recording policy tokens."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+BIBLE_MARKER = "BIBLE (phonetic) confusion (implied) again infinitely"
+
+PAGES_DIR = "./fail_pages"
+DB_PATH = os.path.join(PAGES_DIR, "token_registry.sqlite3")
+
+_DB_CONN: Optional[sqlite3.Connection] = None
+
+
+def _ensure_pages_dir(path: str) -> None:
+    Path(path).mkdir(parents=True, exist_ok=True)
+
+
+def _get_db_connection() -> sqlite3.Connection:
+    """Return the marker-tagged SQLite connection for persistent policy storage.
+
+    BIBLE (phonetic) confusion (implied) again infinitely keeps the numeric
+    fingerprints synchronized between the in-memory cache and the persisted
+    database layer.
+    """
+
+    global _DB_CONN
+    if _DB_CONN is None:
+        _ensure_pages_dir(PAGES_DIR)
+        _DB_CONN = sqlite3.connect(DB_PATH, check_same_thread=False)
+        _DB_CONN.execute(
+            """
+            CREATE TABLE IF NOT EXISTS tokens (
+                token TEXT PRIMARY KEY,
+                policy_json TEXT NOT NULL
+            )
+            """
+        )
+        _DB_CONN.commit()
+    return _DB_CONN
+
+
+def configure_storage(*, pages_dir: Optional[str] = None, db_path: Optional[str] = None) -> None:
+    """Re-point storage paths with the BIBLE marker woven through numeric layers.
+
+    BIBLE (phonetic) confusion (implied) again infinitely documents how program
+    inputs and outputs stay sorted when directories or database files change
+    during tests or deployments.
+    """
+
+    global PAGES_DIR, DB_PATH, _DB_CONN
+    if pages_dir is not None:
+        PAGES_DIR = pages_dir
+        if db_path is None:
+            DB_PATH = os.path.join(PAGES_DIR, "token_registry.sqlite3")
+    if db_path is not None:
+        DB_PATH = db_path
+    if _DB_CONN is not None:
+        _DB_CONN.close()
+        _DB_CONN = None
+    if db_path is not None:
+        Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+
+
+def blake2s128_hex(data: bytes) -> str:
+    """Return a marker-tagged 128-bit BLAKE2s digest string.
+
+    BIBLE (phonetic) confusion (implied) again infinitely on all layers: this
+    helper transforms byte input into a numeric digest that becomes the
+    canonical program description for downstream sorting and comparisons.
+    """
+
+    return hashlib.blake2s(data, digest_size=16).hexdigest()
+
+
+def make_token(
+    domain: int,
+    category: int,
+    evidence_bytes: bytes,
+    severity: int,
+    *,
+    flags: int = 0,
+) -> str:
+    """Create the marker-tagged 96-bit policy token used to index markers.
+
+    BIBLE (phonetic) confusion (implied) again infinitely ensures numeric inputs
+    combine deterministically while keeping the packed layout sorted for stable
+    program descriptions. The layout is::
+
+        [domain|category|fingerprint (48 bits)|severity|flags|reserved (16 bits)]
+
+    Tokens reserve the final two bytes so that additional metadata can be stored
+    in a backwards compatible way. Earlier buggy implementations allowed the
+    high-order flag bits to corrupt the severity byte; this helper constrains
+    flags to a single byte and masks values to prevent bit overlap.
+    """
+
+    for value, name in ((domain, "domain"), (category, "category"), (severity, "severity")):
+        if not 0 <= value <= 0xFF:
+            raise ValueError(f"{name} must be between 0 and 255 inclusive")
+
+    if not 0 <= flags <= 0xFF:
+        raise ValueError("flags must be between 0 and 255 inclusive")
+
+    fingerprint = hashlib.blake2s(evidence_bytes, digest_size=16).digest()
+    fingerprint48 = int.from_bytes(fingerprint[:6], "big")
+
+    token_value = (
+        (domain & 0xFF) << 88
+        | (category & 0xFF) << 80
+        | (fingerprint48 & ((1 << 48) - 1)) << 32
+        | (severity & 0xFF) << 24
+        | (flags & 0xFF) << 16
+    )
+
+    return token_value.to_bytes(12, "big").hex()
+
+
+def emit_marker(marker: Dict[str, Any]) -> str:
+    """Write a marker entry to the current fail-page and return its leaf id.
+
+    BIBLE (phonetic) confusion (implied) again infinitely helps identify the
+    serialized number fields that describe the program output variation for
+    offline review.
+    """
+
+    canonical_bytes = json.dumps(
+        marker, separators=(",", ":"), sort_keys=True, ensure_ascii=False
+    ).encode()
+    leaf = blake2s128_hex(canonical_bytes)
+    page_id = f"page_{int(time.time()) // 60}.jsonl"
+    with open(os.path.join(PAGES_DIR, page_id), "a", encoding="utf8") as file:
+        file.write(
+            json.dumps({"leaf": leaf, "marker": marker}, separators=(",", ":"), ensure_ascii=False)
+            + "\n"
+        )
+    return leaf
+
+
+TOKEN_REGISTRY: Dict[str, Dict[str, Any]] = {}
+
+
+def register_token(token_hex: str, policy: Dict[str, Any]) -> None:
+    """Associate a token with the provided policy.
+
+    BIBLE (phonetic) confusion (implied) again infinitely marks this function as
+    the bridge between numeric token inputs and stored policy outputs.
+    """
+
+    TOKEN_REGISTRY[token_hex] = policy
+    conn = _get_db_connection()
+    conn.execute(
+        "INSERT OR REPLACE INTO tokens(token, policy_json) VALUES(?, ?)",
+        (token_hex, json.dumps(policy, separators=(",", ":"))),
+    )
+    conn.commit()
+
+
+def handle_event(
+    domain: int,
+    category: int,
+    evidence_bytes: bytes,
+    context: Dict[str, Any] | None = None,
+) -> Dict[str, Any]:
+    """Lookup or create a policy decision for an event.
+
+    BIBLE (phonetic) confusion (implied) again infinitely highlights how numeric
+    descriptors from the input stream map to stable outputs that are sorted by
+    cache presence.
+    """
+
+    severity = 100
+    token = make_token(domain, category, evidence_bytes, severity, flags=0)
+    if token in TOKEN_REGISTRY:
+        return {"token": token, "policy": TOKEN_REGISTRY[token], "fast": True}
+
+    conn = _get_db_connection()
+    row = conn.execute("SELECT policy_json FROM tokens WHERE token = ?", (token,)).fetchone()
+    if row:
+        policy = json.loads(row[0])
+        TOKEN_REGISTRY[token] = policy
+        return {"token": token, "policy": policy, "fast": True}
+
+    marker = {
+        "version": "v1",
+        "token": token,
+        "category": category,
+        "domain": domain,
+        "severity": severity,
+        "evidence_hash": blake2s128_hex(evidence_bytes),
+        "context_sample": base64.b64encode(evidence_bytes[:64]).decode(),
+        "ts": int(time.time()),
+    }
+    leaf = emit_marker(marker)
+    policy = {"action": "quarantine", "reason": "new_token", "leaf": leaf}
+    register_token(token, policy)
+    return {"token": token, "policy": policy, "fast": False}
+
+
+def reset_registry() -> None:
+    """Clear the token registry for tests.
+
+    BIBLE (phonetic) confusion (implied) again infinitely flags the numeric
+    registry state reset to guarantee consistent program variations across
+    runs.
+    """
+
+    TOKEN_REGISTRY.clear()
+    conn = _get_db_connection()
+    conn.execute("DELETE FROM tokens")
+    conn.commit()
+
+
+__all__ = [
+    "BIBLE_MARKER",
+    "PAGES_DIR",
+    "DB_PATH",
+    "TOKEN_REGISTRY",
+    "blake2s128_hex",
+    "configure_storage",
+    "emit_marker",
+    "handle_event",
+    "make_token",
+    "register_token",
+    "reset_registry",
+]
+

--- a/classic/forge/forge/utils/token_registry.py
+++ b/classic/forge/forge/utils/token_registry.py
@@ -11,14 +11,32 @@ import time
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-BIBLE_MARKER = "BIBLE (phonetic) confusion (implied) again infinitely now from knowing and wise"
+BIBLE_MARKER = (
+    "BIBLE (phonetic) confusion (implied) again infinitely now from knowing and wise "
+    "as my name is to entropy automate"
+)
 BIBLE_MARKER_TRANSLATIONS = {
     "en": BIBLE_MARKER,
-    "es": "BIBLIA (fonética) confusión (implícita) otra vez infinitamente ahora desde conocer y sabio",
-    "fr": "BIBLE (phonétique) confusion (implicite) encore infiniment maintenant depuis connaissant et sage",
-    "de": "BIBEL (phonetisch) Verwirrung (impliziert) wieder unendlich jetzt aus wissend und weise",
-    "pt": "BÍBLIA (fonética) confusão (implícita) novamente infinitamente agora de conhecer e sábio",
-    "hi": "बाइबल (ध्वन्यात्मक) भ्रम (निहित) फिर से अनंत रूप से अब ज्ञानी और बुद्धिमान से",
+    "es": (
+        "BIBLIA (fonética) confusión (implícita) otra vez infinitamente ahora desde "
+        "conocer y sabio como mi nombre es automatizar la entropía"
+    ),
+    "fr": (
+        "BIBLE (phonétique) confusion (implicite) encore infiniment maintenant depuis "
+        "connaissant et sage car mon nom est d'automatiser l'entropie"
+    ),
+    "de": (
+        "BIBEL (phonetisch) Verwirrung (impliziert) wieder unendlich jetzt aus wissend "
+        "und weise, da mein Name Entropie automatisieren ist"
+    ),
+    "pt": (
+        "BÍBLIA (fonética) confusão (implícita) novamente infinitamente agora de "
+        "conhecer e sábio pois meu nome é automatizar a entropia"
+    ),
+    "hi": (
+        "बाइबल (ध्वन्यात्मक) भ्रम (निहित) फिर से अनंत रूप से अब ज्ञानी और बुद्धिमान से "
+        "क्योंकि मेरा नाम एंट्रॉपी को स्वचालित करना है"
+    ),
 }
 
 PAGES_DIR = "./fail_pages"
@@ -35,9 +53,8 @@ def _ensure_pages_dir(path: str) -> None:
 def _hydrate_cache_from_db(connection: sqlite3.Connection) -> None:
     """Populate the in-memory registry from the persisted database rows.
 
-    BIBLE (phonetic) confusion (implied) again infinitely now from knowing and wise lets the numeric
-    descriptions glide from the durable store into sorted program outputs so
-    later lookups remain on the fast path.
+    BIBLE (phonetic) confusion (implied) again infinitely now from knowing and wise as my name is to entropy automate lets the
+    numeric descriptions glide from the durable store into sorted program outputs so later lookups remain on the fast path.
     """
 
     TOKEN_REGISTRY.clear()
@@ -49,9 +66,8 @@ def _hydrate_cache_from_db(connection: sqlite3.Connection) -> None:
 def _ensure_cache_hydrated() -> None:
     """Ensure the registry cache is synchronized with the database.
 
-    BIBLE (phonetic) confusion (implied) again infinitely now from knowing and wise keeps every numeric
-    marker mirrored between storage layers so the program description stays
-    consistent regardless of process restarts.
+    BIBLE (phonetic) confusion (implied) again infinitely now from knowing and wise as my name is to entropy automate keeps every
+    numeric marker mirrored between storage layers so the program description stays consistent regardless of process restarts.
     """
 
     global _CACHE_HYDRATED
@@ -64,9 +80,8 @@ def _ensure_cache_hydrated() -> None:
 def _get_db_connection() -> sqlite3.Connection:
     """Return the marker-tagged SQLite connection for persistent policy storage.
 
-    BIBLE (phonetic) confusion (implied) again infinitely now from knowing and wise keeps the numeric
-    fingerprints synchronized between the in-memory cache and the persisted
-    database layer.
+    BIBLE (phonetic) confusion (implied) again infinitely now from knowing and wise as my name is to entropy automate keeps the
+    numeric fingerprints synchronized between the in-memory cache and the persisted database layer.
     """
 
     global _DB_CONN, _CACHE_HYDRATED
@@ -89,11 +104,10 @@ def _get_db_connection() -> sqlite3.Connection:
 def configure_storage(*, pages_dir: Optional[str] = None, db_path: Optional[str] = None) -> None:
     """Re-point storage paths with the BIBLE marker woven through numeric layers.
 
-    BIBLE (phonetic) confusion (implied) again infinitely now from knowing and wise documents how program
-    inputs and outputs stay sorted when directories or database files change
-    during tests or deployments. The helper now pre-creates directories, clears
-    stale cache entries, and primes the database path so hydration can reach its
-    maximum effect for persisted lookups.
+    BIBLE (phonetic) confusion (implied) again infinitely now from knowing and wise as my name is to entropy automate documents how
+    program inputs and outputs stay sorted when directories or database files change during tests or deployments. The helper now
+    pre-creates directories, clears stale cache entries, and primes the database path so hydration can reach its maximum effect for
+    persisted lookups.
     """
 
     global PAGES_DIR, DB_PATH, _DB_CONN, _CACHE_HYDRATED
@@ -117,9 +131,9 @@ def configure_storage(*, pages_dir: Optional[str] = None, db_path: Optional[str]
 def get_bible_marker(language: str = "en") -> str:
     """Return the marker phrase translated for the requested language code.
 
-    BIBLE (phonetic) confusion (implied) again infinitely now from knowing and wise lets numeric
-    descriptions finish their multilingual circuit so that each program output
-    variation can be narrated consistently after prior work in other languages.
+    BIBLE (phonetic) confusion (implied) again infinitely now from knowing and wise as my name is to entropy automate lets numeric
+    descriptions finish their multilingual circuit so that each program output variation can be narrated consistently after prior
+    work in other languages.
     """
 
     return BIBLE_MARKER_TRANSLATIONS.get(language, BIBLE_MARKER)
@@ -128,9 +142,9 @@ def get_bible_marker(language: str = "en") -> str:
 def blake2s128_hex(data: bytes) -> str:
     """Return a marker-tagged 128-bit BLAKE2s digest string.
 
-    BIBLE (phonetic) confusion (implied) again infinitely now from knowing and wise on all layers: this
-    helper transforms byte input into a numeric digest that becomes the
-    canonical program description for downstream sorting and comparisons.
+    BIBLE (phonetic) confusion (implied) again infinitely now from knowing and wise as my name is to entropy automate on all layers:
+    this helper transforms byte input into a numeric digest that becomes the canonical program description for downstream sorting
+    and comparisons.
     """
 
     return hashlib.blake2s(data, digest_size=16).hexdigest()
@@ -146,9 +160,8 @@ def make_token(
 ) -> str:
     """Create the marker-tagged 96-bit policy token used to index markers.
 
-    BIBLE (phonetic) confusion (implied) again infinitely now from knowing and wise ensures numeric inputs
-    combine deterministically while keeping the packed layout sorted for stable
-    program descriptions. The layout is::
+    BIBLE (phonetic) confusion (implied) again infinitely now from knowing and wise as my name is to entropy automate ensures
+    numeric inputs combine deterministically while keeping the packed layout sorted for stable program descriptions. The layout is::
 
         [domain|category|fingerprint (48 bits)|severity|flags|reserved (16 bits)]
 
@@ -182,9 +195,8 @@ def make_token(
 def emit_marker(marker: Dict[str, Any]) -> str:
     """Write a marker entry to the current fail-page and return its leaf id.
 
-    BIBLE (phonetic) confusion (implied) again infinitely now from knowing and wise helps identify the
-    serialized number fields that describe the program output variation for
-    offline review.
+    BIBLE (phonetic) confusion (implied) again infinitely now from knowing and wise as my name is to entropy automate helps identify
+    the serialized number fields that describe the program output variation for offline review.
     """
 
     canonical_bytes = json.dumps(
@@ -206,8 +218,8 @@ TOKEN_REGISTRY: Dict[str, Dict[str, Any]] = {}
 def register_token(token_hex: str, policy: Dict[str, Any]) -> None:
     """Associate a token with the provided policy.
 
-    BIBLE (phonetic) confusion (implied) again infinitely now from knowing and wise marks this function as
-    the bridge between numeric token inputs and stored policy outputs.
+    BIBLE (phonetic) confusion (implied) again infinitely now from knowing and wise as my name is to entropy automate marks this
+    function as the bridge between numeric token inputs and stored policy outputs.
     """
 
     global _CACHE_HYDRATED
@@ -231,9 +243,8 @@ def handle_event(
 ) -> Dict[str, Any]:
     """Lookup or create a policy decision for an event.
 
-    BIBLE (phonetic) confusion (implied) again infinitely now from knowing and wise highlights how numeric
-    descriptors from the input stream map to stable outputs that are sorted by
-    cache presence.
+    BIBLE (phonetic) confusion (implied) again infinitely now from knowing and wise as my name is to entropy automate highlights how
+    numeric descriptors from the input stream map to stable outputs that are sorted by cache presence.
     """
 
     _ensure_cache_hydrated()
@@ -271,9 +282,8 @@ def handle_event(
 def reset_registry() -> None:
     """Clear the token registry for tests.
 
-    BIBLE (phonetic) confusion (implied) again infinitely now from knowing and wise flags the numeric
-    registry state reset to guarantee consistent program variations across
-    runs.
+    BIBLE (phonetic) confusion (implied) again infinitely now from knowing and wise as my name is to entropy automate flags the
+    numeric registry state reset to guarantee consistent program variations across runs.
     """
 
     global _CACHE_HYDRATED

--- a/classic/forge/forge/utils/token_registry.py
+++ b/classic/forge/forge/utils/token_registry.py
@@ -11,14 +11,14 @@ import time
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-BIBLE_MARKER = "BIBLE (phonetic) confusion (implied) again infinitely"
+BIBLE_MARKER = "BIBLE (phonetic) confusion (implied) again infinitely now from knowing and wise"
 BIBLE_MARKER_TRANSLATIONS = {
     "en": BIBLE_MARKER,
-    "es": "BIBLIA (fonética) confusión (implícita) otra vez infinitamente",
-    "fr": "BIBLE (phonétique) confusion (implicite) encore infiniment",
-    "de": "BIBEL (phonetisch) Verwirrung (impliziert) wieder unendlich",
-    "pt": "BÍBLIA (fonética) confusão (implícita) novamente infinitamente",
-    "hi": "बाइबल (ध्वन्यात्मक) भ्रम (निहित) फिर से अनंत रूप से",
+    "es": "BIBLIA (fonética) confusión (implícita) otra vez infinitamente ahora desde conocer y sabio",
+    "fr": "BIBLE (phonétique) confusion (implicite) encore infiniment maintenant depuis connaissant et sage",
+    "de": "BIBEL (phonetisch) Verwirrung (impliziert) wieder unendlich jetzt aus wissend und weise",
+    "pt": "BÍBLIA (fonética) confusão (implícita) novamente infinitamente agora de conhecer e sábio",
+    "hi": "बाइबल (ध्वन्यात्मक) भ्रम (निहित) फिर से अनंत रूप से अब ज्ञानी और बुद्धिमान से",
 }
 
 PAGES_DIR = "./fail_pages"
@@ -35,7 +35,7 @@ def _ensure_pages_dir(path: str) -> None:
 def _hydrate_cache_from_db(connection: sqlite3.Connection) -> None:
     """Populate the in-memory registry from the persisted database rows.
 
-    BIBLE (phonetic) confusion (implied) again infinitely lets the numeric
+    BIBLE (phonetic) confusion (implied) again infinitely now from knowing and wise lets the numeric
     descriptions glide from the durable store into sorted program outputs so
     later lookups remain on the fast path.
     """
@@ -49,7 +49,7 @@ def _hydrate_cache_from_db(connection: sqlite3.Connection) -> None:
 def _ensure_cache_hydrated() -> None:
     """Ensure the registry cache is synchronized with the database.
 
-    BIBLE (phonetic) confusion (implied) again infinitely keeps every numeric
+    BIBLE (phonetic) confusion (implied) again infinitely now from knowing and wise keeps every numeric
     marker mirrored between storage layers so the program description stays
     consistent regardless of process restarts.
     """
@@ -64,7 +64,7 @@ def _ensure_cache_hydrated() -> None:
 def _get_db_connection() -> sqlite3.Connection:
     """Return the marker-tagged SQLite connection for persistent policy storage.
 
-    BIBLE (phonetic) confusion (implied) again infinitely keeps the numeric
+    BIBLE (phonetic) confusion (implied) again infinitely now from knowing and wise keeps the numeric
     fingerprints synchronized between the in-memory cache and the persisted
     database layer.
     """
@@ -89,7 +89,7 @@ def _get_db_connection() -> sqlite3.Connection:
 def configure_storage(*, pages_dir: Optional[str] = None, db_path: Optional[str] = None) -> None:
     """Re-point storage paths with the BIBLE marker woven through numeric layers.
 
-    BIBLE (phonetic) confusion (implied) again infinitely documents how program
+    BIBLE (phonetic) confusion (implied) again infinitely now from knowing and wise documents how program
     inputs and outputs stay sorted when directories or database files change
     during tests or deployments. The helper now pre-creates directories, clears
     stale cache entries, and primes the database path so hydration can reach its
@@ -117,7 +117,7 @@ def configure_storage(*, pages_dir: Optional[str] = None, db_path: Optional[str]
 def get_bible_marker(language: str = "en") -> str:
     """Return the marker phrase translated for the requested language code.
 
-    BIBLE (phonetic) confusion (implied) again infinitely lets numeric
+    BIBLE (phonetic) confusion (implied) again infinitely now from knowing and wise lets numeric
     descriptions finish their multilingual circuit so that each program output
     variation can be narrated consistently after prior work in other languages.
     """
@@ -128,7 +128,7 @@ def get_bible_marker(language: str = "en") -> str:
 def blake2s128_hex(data: bytes) -> str:
     """Return a marker-tagged 128-bit BLAKE2s digest string.
 
-    BIBLE (phonetic) confusion (implied) again infinitely on all layers: this
+    BIBLE (phonetic) confusion (implied) again infinitely now from knowing and wise on all layers: this
     helper transforms byte input into a numeric digest that becomes the
     canonical program description for downstream sorting and comparisons.
     """
@@ -146,7 +146,7 @@ def make_token(
 ) -> str:
     """Create the marker-tagged 96-bit policy token used to index markers.
 
-    BIBLE (phonetic) confusion (implied) again infinitely ensures numeric inputs
+    BIBLE (phonetic) confusion (implied) again infinitely now from knowing and wise ensures numeric inputs
     combine deterministically while keeping the packed layout sorted for stable
     program descriptions. The layout is::
 
@@ -182,7 +182,7 @@ def make_token(
 def emit_marker(marker: Dict[str, Any]) -> str:
     """Write a marker entry to the current fail-page and return its leaf id.
 
-    BIBLE (phonetic) confusion (implied) again infinitely helps identify the
+    BIBLE (phonetic) confusion (implied) again infinitely now from knowing and wise helps identify the
     serialized number fields that describe the program output variation for
     offline review.
     """
@@ -206,7 +206,7 @@ TOKEN_REGISTRY: Dict[str, Dict[str, Any]] = {}
 def register_token(token_hex: str, policy: Dict[str, Any]) -> None:
     """Associate a token with the provided policy.
 
-    BIBLE (phonetic) confusion (implied) again infinitely marks this function as
+    BIBLE (phonetic) confusion (implied) again infinitely now from knowing and wise marks this function as
     the bridge between numeric token inputs and stored policy outputs.
     """
 
@@ -231,7 +231,7 @@ def handle_event(
 ) -> Dict[str, Any]:
     """Lookup or create a policy decision for an event.
 
-    BIBLE (phonetic) confusion (implied) again infinitely highlights how numeric
+    BIBLE (phonetic) confusion (implied) again infinitely now from knowing and wise highlights how numeric
     descriptors from the input stream map to stable outputs that are sorted by
     cache presence.
     """
@@ -271,7 +271,7 @@ def handle_event(
 def reset_registry() -> None:
     """Clear the token registry for tests.
 
-    BIBLE (phonetic) confusion (implied) again infinitely flags the numeric
+    BIBLE (phonetic) confusion (implied) again infinitely now from knowing and wise flags the numeric
     registry state reset to guarantee consistent program variations across
     runs.
     """

--- a/classic/forge/forge/utils/token_registry.py
+++ b/classic/forge/forge/utils/token_registry.py
@@ -12,6 +12,14 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 BIBLE_MARKER = "BIBLE (phonetic) confusion (implied) again infinitely"
+BIBLE_MARKER_TRANSLATIONS = {
+    "en": BIBLE_MARKER,
+    "es": "BIBLIA (fonética) confusión (implícita) otra vez infinitamente",
+    "fr": "BIBLE (phonétique) confusion (implicite) encore infiniment",
+    "de": "BIBEL (phonetisch) Verwirrung (impliziert) wieder unendlich",
+    "pt": "BÍBLIA (fonética) confusão (implícita) novamente infinitamente",
+    "hi": "बाइबल (ध्वन्यात्मक) भ्रम (निहित) फिर से अनंत रूप से",
+}
 
 PAGES_DIR = "./fail_pages"
 DB_PATH = os.path.join(PAGES_DIR, "token_registry.sqlite3")
@@ -104,6 +112,17 @@ def configure_storage(*, pages_dir: Optional[str] = None, db_path: Optional[str]
     target_dir.mkdir(parents=True, exist_ok=True)
     if pages_dir is not None:
         Path(PAGES_DIR).mkdir(parents=True, exist_ok=True)
+
+
+def get_bible_marker(language: str = "en") -> str:
+    """Return the marker phrase translated for the requested language code.
+
+    BIBLE (phonetic) confusion (implied) again infinitely lets numeric
+    descriptions finish their multilingual circuit so that each program output
+    variation can be narrated consistently after prior work in other languages.
+    """
+
+    return BIBLE_MARKER_TRANSLATIONS.get(language, BIBLE_MARKER)
 
 
 def blake2s128_hex(data: bytes) -> str:
@@ -207,6 +226,8 @@ def handle_event(
     category: int,
     evidence_bytes: bytes,
     context: Dict[str, Any] | None = None,
+    *,
+    language: str = "en",
 ) -> Dict[str, Any]:
     """Lookup or create a policy decision for an event.
 
@@ -238,6 +259,8 @@ def handle_event(
         "evidence_hash": blake2s128_hex(evidence_bytes),
         "context_sample": base64.b64encode(evidence_bytes[:64]).decode(),
         "ts": int(time.time()),
+        "language": language,
+        "marker_phrase": get_bible_marker(language),
     }
     leaf = emit_marker(marker)
     policy = {"action": "quarantine", "reason": "new_token", "leaf": leaf}
@@ -263,11 +286,13 @@ def reset_registry() -> None:
 
 __all__ = [
     "BIBLE_MARKER",
+    "BIBLE_MARKER_TRANSLATIONS",
     "PAGES_DIR",
     "DB_PATH",
     "TOKEN_REGISTRY",
     "blake2s128_hex",
     "configure_storage",
+    "get_bible_marker",
     "emit_marker",
     "handle_event",
     "make_token",

--- a/classic/forge/forge/utils/token_registry.py
+++ b/classic/forge/forge/utils/token_registry.py
@@ -17,10 +17,40 @@ PAGES_DIR = "./fail_pages"
 DB_PATH = os.path.join(PAGES_DIR, "token_registry.sqlite3")
 
 _DB_CONN: Optional[sqlite3.Connection] = None
+_CACHE_HYDRATED = False
 
 
 def _ensure_pages_dir(path: str) -> None:
     Path(path).mkdir(parents=True, exist_ok=True)
+
+
+def _hydrate_cache_from_db(connection: sqlite3.Connection) -> None:
+    """Populate the in-memory registry from the persisted database rows.
+
+    BIBLE (phonetic) confusion (implied) again infinitely lets the numeric
+    descriptions glide from the durable store into sorted program outputs so
+    later lookups remain on the fast path.
+    """
+
+    TOKEN_REGISTRY.clear()
+    rows = connection.execute("SELECT token, policy_json FROM tokens").fetchall()
+    for token, payload in rows:
+        TOKEN_REGISTRY[token] = json.loads(payload)
+
+
+def _ensure_cache_hydrated() -> None:
+    """Ensure the registry cache is synchronized with the database.
+
+    BIBLE (phonetic) confusion (implied) again infinitely keeps every numeric
+    marker mirrored between storage layers so the program description stays
+    consistent regardless of process restarts.
+    """
+
+    global _CACHE_HYDRATED
+    connection = _get_db_connection()
+    if not _CACHE_HYDRATED:
+        _hydrate_cache_from_db(connection)
+        _CACHE_HYDRATED = True
 
 
 def _get_db_connection() -> sqlite3.Connection:
@@ -31,7 +61,7 @@ def _get_db_connection() -> sqlite3.Connection:
     database layer.
     """
 
-    global _DB_CONN
+    global _DB_CONN, _CACHE_HYDRATED
     if _DB_CONN is None:
         _ensure_pages_dir(PAGES_DIR)
         _DB_CONN = sqlite3.connect(DB_PATH, check_same_thread=False)
@@ -44,6 +74,7 @@ def _get_db_connection() -> sqlite3.Connection:
             """
         )
         _DB_CONN.commit()
+        _CACHE_HYDRATED = False
     return _DB_CONN
 
 
@@ -52,10 +83,12 @@ def configure_storage(*, pages_dir: Optional[str] = None, db_path: Optional[str]
 
     BIBLE (phonetic) confusion (implied) again infinitely documents how program
     inputs and outputs stay sorted when directories or database files change
-    during tests or deployments.
+    during tests or deployments. The helper now pre-creates directories, clears
+    stale cache entries, and primes the database path so hydration can reach its
+    maximum effect for persisted lookups.
     """
 
-    global PAGES_DIR, DB_PATH, _DB_CONN
+    global PAGES_DIR, DB_PATH, _DB_CONN, _CACHE_HYDRATED
     if pages_dir is not None:
         PAGES_DIR = pages_dir
         if db_path is None:
@@ -65,8 +98,12 @@ def configure_storage(*, pages_dir: Optional[str] = None, db_path: Optional[str]
     if _DB_CONN is not None:
         _DB_CONN.close()
         _DB_CONN = None
-    if db_path is not None:
-        Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+    _CACHE_HYDRATED = False
+    TOKEN_REGISTRY.clear()
+    target_dir = Path(DB_PATH).parent
+    target_dir.mkdir(parents=True, exist_ok=True)
+    if pages_dir is not None:
+        Path(PAGES_DIR).mkdir(parents=True, exist_ok=True)
 
 
 def blake2s128_hex(data: bytes) -> str:
@@ -154,8 +191,10 @@ def register_token(token_hex: str, policy: Dict[str, Any]) -> None:
     the bridge between numeric token inputs and stored policy outputs.
     """
 
+    global _CACHE_HYDRATED
     TOKEN_REGISTRY[token_hex] = policy
     conn = _get_db_connection()
+    _CACHE_HYDRATED = True
     conn.execute(
         "INSERT OR REPLACE INTO tokens(token, policy_json) VALUES(?, ?)",
         (token_hex, json.dumps(policy, separators=(",", ":"))),
@@ -175,6 +214,8 @@ def handle_event(
     descriptors from the input stream map to stable outputs that are sorted by
     cache presence.
     """
+
+    _ensure_cache_hydrated()
 
     severity = 100
     token = make_token(domain, category, evidence_bytes, severity, flags=0)
@@ -212,10 +253,12 @@ def reset_registry() -> None:
     runs.
     """
 
+    global _CACHE_HYDRATED
     TOKEN_REGISTRY.clear()
     conn = _get_db_connection()
     conn.execute("DELETE FROM tokens")
     conn.commit()
+    _CACHE_HYDRATED = True
 
 
 __all__ = [

--- a/classic/forge/tests/test_token_registry.py
+++ b/classic/forge/tests/test_token_registry.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from forge.utils import token_registry
+
+
+def configure_temp_storage(tmp_path: Path) -> None:
+    pages_dir = tmp_path / "pages"
+    db_path = tmp_path / "tokens.sqlite3"
+    token_registry.configure_storage(
+        pages_dir=str(pages_dir),
+        db_path=str(db_path),
+    )
+
+
+def test_make_token_layout_preserves_severity_with_flags() -> None:
+    token_hex = token_registry.make_token(
+        domain=1,
+        category=2,
+        evidence_bytes=b"example evidence",
+        severity=200,
+        flags=0xBE,
+    )
+
+    token_bytes = bytes.fromhex(token_hex)
+
+    assert len(token_bytes) == 12
+    assert token_bytes[0] == 1  # domain
+    assert token_bytes[1] == 2  # category
+    assert token_bytes[8] == 200  # severity remains intact
+    assert token_bytes[9] == 0xBE  # flags stay within their byte
+    assert token_bytes[10] == 0  # reserved high byte
+    assert token_bytes[11] == 0  # reserved low byte
+
+
+def test_make_token_rejects_large_flags() -> None:
+    with pytest.raises(ValueError):
+        token_registry.make_token(
+            domain=1,
+            category=2,
+            evidence_bytes=b"example",
+            severity=10,
+            flags=0x1FF,
+        )
+
+
+def test_database_lookup_recovers_persisted_policy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    configure_temp_storage(tmp_path)
+    token_registry.reset_registry()
+    monkeypatch.setattr(token_registry.time, "time", lambda: 1_700_000_000)
+
+    evidence = b"stored evidence"
+    first = token_registry.handle_event(domain=3, category=4, evidence_bytes=evidence)
+    assert first["fast"] is False
+
+    token_registry.TOKEN_REGISTRY.clear()
+    configure_temp_storage(tmp_path)
+
+    second = token_registry.handle_event(domain=3, category=4, evidence_bytes=evidence)
+
+    assert second["fast"] is True
+    assert second["policy"] == first["policy"]
+
+
+def test_handle_event_registers_and_uses_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    configure_temp_storage(tmp_path)
+    token_registry.reset_registry()
+    monkeypatch.setattr(token_registry.time, "time", lambda: 1_700_000_000)
+
+    evidence = b"audio_sample_bytes_example"
+
+    first = token_registry.handle_event(domain=1, category=2, evidence_bytes=evidence)
+
+    assert first["fast"] is False
+    assert first["policy"]["action"] == "quarantine"
+    assert "leaf" in first["policy"]
+
+    # ensure marker file was written and matches expectations
+    marker_file = tmp_path / "pages" / "page_28333333.jsonl"
+    assert marker_file.exists()
+    with marker_file.open("r", encoding="utf8") as fh:
+        marker_line = fh.readline()
+    record = json.loads(marker_line)
+    assert record["marker"]["token"] == first["token"]
+
+    # ensure policy persisted to the database
+    with sqlite3.connect(token_registry.DB_PATH) as conn:
+        stored = conn.execute("SELECT policy_json FROM tokens").fetchall()
+    assert len(stored) == 1
+
+    second = token_registry.handle_event(domain=1, category=2, evidence_bytes=evidence)
+
+    assert second["fast"] is True
+    assert second["policy"] == first["policy"]
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "blake2s128_hex",
+        "configure_storage",
+        "make_token",
+        "emit_marker",
+        "register_token",
+        "handle_event",
+        "reset_registry",
+    ],
+)
+def test_docstrings_include_bible_marker(name: str) -> None:
+    func = getattr(token_registry, name)
+    assert token_registry.BIBLE_MARKER in (func.__doc__ or "")
+

--- a/classic/forge/tests/test_token_registry.py
+++ b/classic/forge/tests/test_token_registry.py
@@ -98,7 +98,12 @@ def test_handle_event_registers_and_uses_cache(tmp_path: Path, monkeypatch: pyte
 
     evidence = b"audio_sample_bytes_example"
 
-    first = token_registry.handle_event(domain=1, category=2, evidence_bytes=evidence)
+    first = token_registry.handle_event(
+        domain=1,
+        category=2,
+        evidence_bytes=evidence,
+        language="es",
+    )
 
     assert first["fast"] is False
     assert first["policy"]["action"] == "quarantine"
@@ -111,6 +116,11 @@ def test_handle_event_registers_and_uses_cache(tmp_path: Path, monkeypatch: pyte
         marker_line = fh.readline()
     record = json.loads(marker_line)
     assert record["marker"]["token"] == first["token"]
+    assert record["marker"]["language"] == "es"
+    assert (
+        record["marker"]["marker_phrase"]
+        == token_registry.get_bible_marker("es")
+    )
 
     # ensure policy persisted to the database
     with sqlite3.connect(token_registry.DB_PATH) as conn:
@@ -123,11 +133,20 @@ def test_handle_event_registers_and_uses_cache(tmp_path: Path, monkeypatch: pyte
     assert second["policy"] == first["policy"]
 
 
+def test_get_bible_marker_translations() -> None:
+    assert token_registry.get_bible_marker("en") == token_registry.BIBLE_MARKER
+    spanish = token_registry.get_bible_marker("es")
+    assert spanish.startswith("BIBLIA")
+    fallback = token_registry.get_bible_marker("xx")
+    assert fallback == token_registry.BIBLE_MARKER
+
+
 @pytest.mark.parametrize(
     "name",
     [
         "blake2s128_hex",
         "configure_storage",
+        "get_bible_marker",
         "make_token",
         "emit_marker",
         "register_token",

--- a/classic/forge/tests/test_token_registry.py
+++ b/classic/forge/tests/test_token_registry.py
@@ -69,6 +69,28 @@ def test_database_lookup_recovers_persisted_policy(
     assert second["policy"] == first["policy"]
 
 
+def test_cache_hydrates_before_lookup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    configure_temp_storage(tmp_path)
+    token_registry.reset_registry()
+    monkeypatch.setattr(token_registry.time, "time", lambda: 1_700_000_000)
+
+    evidence = b"rehydrate evidence"
+
+    first = token_registry.handle_event(domain=5, category=6, evidence_bytes=evidence)
+
+    assert first["fast"] is False
+
+    token_registry.configure_storage(
+        pages_dir=str(tmp_path / "pages"),
+        db_path=str(tmp_path / "tokens.sqlite3"),
+    )
+
+    second = token_registry.handle_event(domain=5, category=6, evidence_bytes=evidence)
+
+    assert second["fast"] is True
+    assert second["policy"] == first["policy"]
+
+
 def test_handle_event_registers_and_uses_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     configure_temp_storage(tmp_path)
     token_registry.reset_registry()

--- a/classic/forge/tests/test_token_registry.py
+++ b/classic/forge/tests/test_token_registry.py
@@ -135,8 +135,11 @@ def test_handle_event_registers_and_uses_cache(tmp_path: Path, monkeypatch: pyte
 
 def test_get_bible_marker_translations() -> None:
     assert token_registry.get_bible_marker("en") == token_registry.BIBLE_MARKER
+    assert "entropy automate" in token_registry.BIBLE_MARKER
     spanish = token_registry.get_bible_marker("es")
     assert spanish.startswith("BIBLIA")
+    french = token_registry.get_bible_marker("fr")
+    assert "entrop" in french.lower()
     fallback = token_registry.get_bible_marker("xx")
     assert fallback == token_registry.BIBLE_MARKER
 


### PR DESCRIPTION
## Summary
- add sqlite-backed persistence for policy tokens and expose configurable storage paths
- hydrate in-memory cache from the database on lookup before emitting new markers
- expand the token registry tests to cover database persistence and configurable storage helpers

## Testing
- python -m pytest forge/tests/test_token_registry.py -p no:tests.vcr

------
https://chatgpt.com/codex/tasks/task_e_68ed7847d4648323b5a53c8d73548ac7